### PR TITLE
fix: wrong github link and company style of name

### DIFF
--- a/src/components/Intro.tsx
+++ b/src/components/Intro.tsx
@@ -67,7 +67,7 @@ export function Intro() {
         <IconLink href="https://www.iroh.computer/docs" icon={BookIcon} className="flex-none">
           Docs
         </IconLink>
-        <IconLink href="https://github.com/n0-computer/iroh/tree/main/iroh" icon={GitHubIcon} className="flex-none">
+        <IconLink href="https://github.com/n0-computer/dumbpipe" icon={GitHubIcon} className="flex-none">
           GitHub
         </IconLink>
         <IconLink href="https://iroh.computer/discord" icon={DiscordIcon} className="flex-none">


### PR DESCRIPTION
- **fix: github link leads to iroh instead of dumpipe**
~~- **style: number 0 can look like a buggy twitter follower count**~~

I didn't do it but noticed you have not updated the twitter svg too.
