### PR TITLE
install.sh: Avoid interacting with tape drives on systems that have them

### DIFF
--- a/public/install.sh
+++ b/public/install.sh
@@ -27,4 +27,4 @@ release_target_url=$(
     sed -re 's/.*: "([^"]+)".*/\1/' \
 )
 
-curl -sL "$release_target_url" | tar xz
+curl -sL "$release_target_url" | tar xzf -


### PR DESCRIPTION
Fixes this:
```
root@pve:~# curl -sL https://www.dumbpipe.dev/install.sh | sh
Downloading n0-computer/dumbpipe for linux-x86_64
tar (child): /dev/nst0: Cannot read: Input/output error
tar (child): At beginning of tape, quitting now
tar (child): Error is not recoverable: exiting now

gzip: stdin: unexpected end of file
tar: Child returned status 2
tar: Error is not recoverable: exiting now
root@pve:~# 
```

`tar xf` only implicitly reads from stdin if there isn't a tape drive available for tar to work with. This PR makes the intended behavior explicit.